### PR TITLE
Support webpack2's harmony exports['default']

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,6 @@ module.exports = function applyLoader(source) {
   }
 
   var json = JSON.stringify(args);
-  source += "\n\nmodule.exports = module.exports.apply(module, " + json + ")";
+  source += "\n\nexports['default'] = exports['default'].apply(module, " + json + ")";
   return source;
 };


### PR DESCRIPTION
Webpack 2 is exporting default exports as `exports['default']` instead of `module.exports`. That means that this package doesn't work with webpack 2. This commit fixes that.

Since it's still in beta, I don't really expect you to just go ahead and accept this PR right now, but I'm just putting it here for the record.